### PR TITLE
Add output logs for final evaluation results

### DIFF
--- a/bionlp/taggers/rnn_feature/tagger.py
+++ b/bionlp/taggers/rnn_feature/tagger.py
@@ -77,7 +77,7 @@ def train_NN(train, crf_output, lstm_output, train_indices, compute_cost, comput
                 update_monitoring(params['monitoring-file'])
 
     sl.info("Final Validation eval")
-    evaluate_neuralnet(lstm_output, x_dev, mask_dev, y_dev, strict=True)
+    evaluate_neuralnet(lstm_output, x_dev, mask_dev, y_dev, strict=True, final_eval=True)
 
 
 def perform_training_iteration(train, compute_cost, compute_acc, compute_cost_regularization, x_train, mask_train, y_train, params, iter_num, num_batches):
@@ -160,7 +160,7 @@ def callback_NN(compute_cost, compute_acc, X_test, mask_test, y_test):
     return val_acc / num_valid_batches, val_loss / num_valid_batches
 
 
-def evaluate_neuralnet(lstm_output, X_test, mask_test, y_test, z_test=None, strict=False, verbose=True):
+def evaluate_neuralnet(lstm_output, X_test, mask_test, y_test, z_test=None, strict=False, verbose=True, final_eval=False):
     if params['trainable'] is False and params['noeval'] == True:
         verbose = False
     if z_test == None:
@@ -193,7 +193,7 @@ def evaluate_neuralnet(lstm_output, X_test, mask_test, y_test, z_test=None, stri
                                           i2t[l] for l in predicted], verbose=verbose, preMsg='NN:', flat_list=True)
     if strict:
         res = eval_metrics.get_Exact_Metrics(
-            label_sent, predicted_sent, verbose=verbose)
+            label_sent, predicted_sent, verbose=verbose, final_eval=final_eval)
         sl.info('Output number of tokens are {0}'.format(
             sum(len(_) for _ in predicted_sent)))
 

--- a/loop_training.py
+++ b/loop_training.py
@@ -1,6 +1,7 @@
 from train import main
 import datetime
 from bionlp.utils.crf_arguments import crf_model_arguments
+import bionlp.evaluate.evaluation as ev
 
 
 if __name__ == '__main__':
@@ -14,4 +15,5 @@ if __name__ == '__main__':
     today = datetime.date.today().isoformat()
     for idx in range(10):
         config_params['monitoring-file'] = "data/logs/monitor_{0}_{1}.pkl".format(today, idx)
+        ev.final_eval_out_file = "data/logs/eval_{0}_{1}.txt".format(today, idx)
         main(config_params)


### PR DESCRIPTION
Add output logs for final evaluation results

After the complete training is done, the final evaluation results are calculated on a set of validation data and are written into a new log file. The evaluation results contain:

- the confusion matrix
- the f1-score, precision and recall per tag
- the total number of tags, avg. f1-score, avg. precision and avg. recall for all tags

When I tested this for multiple training procedures, I noticed that the amount of tags that are evaluated at the end of each training differs from training to training. I assume that this is due to us using cross validation on randomly shuffled data, and thus ending up with a different set of validation data in the end each time.